### PR TITLE
Don't ignore ack errors

### DIFF
--- a/proximo-server/nats-streaming.go
+++ b/proximo-server/nats-streaming.go
@@ -47,7 +47,10 @@ func (h *natsStreamingHandler) HandleConsume(ctx context.Context, consumer, topi
 						ackErrors <- fmt.Errorf("unexpected message sequence. was %v but wanted %v.", seq, msg.Sequence)
 						return
 					}
-					msg.Ack()
+					if err := msg.Ack(); err != nil {
+						ackErrors <- fmt.Errorf("failed to ack message with NATS: %v.", err.Error())
+						return
+					}
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
We were ignoring errors coming back from NATS when acking. Don't do
that.