### PR TITLE
fix for dropped connections

### DIFF
--- a/proximo-server/main.go
+++ b/proximo-server/main.go
@@ -6,9 +6,11 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jawher/mow.cli"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 func main() {
@@ -136,7 +138,11 @@ func main() {
 			if err != nil {
 				log.Fatalf("failed to listen: %v", err)
 			}
-			var opts []grpc.ServerOption
+			opts := []grpc.ServerOption{
+				grpc.KeepaliveParams(keepalive.ServerParameters{
+					Time: 5 * time.Minute,
+				}),
+			}
 			grpcServer := grpc.NewServer(opts...)
 			kh := newMemHandler()
 			log.Printf("Using in memory testing backend")


### PR DESCRIPTION
this introduces a change to the grpc server to avoid the problem of
'transport closing' dropped connections on aws ingresses