### PR TITLE
Go proximo consumer: wait on WaitGroup last

### DIFF
--- a/proximoc-go/client.go
+++ b/proximoc-go/client.go
@@ -25,6 +25,9 @@ func ConsumeContextTLS(ctx context.Context, proximoAddress string, consumer stri
 
 func consumeContext(ctx context.Context, proximoAddress string, consumer string, topic string, f func(*Message) error, opts ...grpc.DialOption) error {
 
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
 	conn, err := grpc.DialContext(ctx, proximoAddress, opts...)
 	if err != nil {
 		grpclog.Fatalf("fail to dial: %v", err)
@@ -41,9 +44,6 @@ func consumeContext(ctx context.Context, proximoAddress string, consumer string,
 
 	handled := make(chan string)
 	errs := make(chan error, 2)
-
-	var wg sync.WaitGroup
-	defer wg.Wait()
 
 	ins := make(chan *Message, 16) // TODO: make buffer size configurable?
 


### PR DESCRIPTION
When an error is returned by the caller supplied function,
`consumeContext` will return that error (after receiving on the errs
channel). In doing so, 3 deferred functions are called, in the following
order (reverse to code order):
* `wg.Wait()`
* `stream.CloseSend()`
* `conn.Close()`

The problem encountered with this is that the first goroutine which is
receiving inbound messages will not stop, and `wg.Wait()` will block
indefinitely.

This change adjust the order of deferred function calls so that they are
invoked as follows:
* `stream.CloseSend()`
* `conn.Close()`
* `wg.Wait()`

This resolves the issue as closing the stream and connection causes the
problematic goroutine to finish. With `wg.Done()` called by both
goroutines, `wg.Wait()` returns, meaning `consumeContext` can return.