### PR TITLE
Replace usages of grpclog.Fatalf(..)

### DIFF
--- a/proximoc-go/client.go
+++ b/proximoc-go/client.go
@@ -5,14 +5,13 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
-	"errors"
 	"io"
 	"log"
 	"sync"
 
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/grpclog"
 )
 
 func ConsumeContext(ctx context.Context, proximoAddress string, consumer string, topic string, f func(*Message) error) error {
@@ -30,14 +29,14 @@ func consumeContext(ctx context.Context, proximoAddress string, consumer string,
 
 	conn, err := grpc.DialContext(ctx, proximoAddress, opts...)
 	if err != nil {
-		grpclog.Fatalf("fail to dial: %v", err)
+		return errors.Wrapf(err, "fail to dial %s", proximoAddress)
 	}
 	defer conn.Close()
 	client := NewMessageSourceClient(conn)
 
 	stream, err := client.Consume(ctx)
 	if err != nil {
-		grpclog.Fatalf("%v.Consume(_) = _, %v", client, err)
+		return errors.Wrap(err, "fail to consume")
 	}
 
 	defer stream.CloseSend()


### PR DESCRIPTION
These result in the process exiting, without giving the chance for the
calling code to make any attempts to recover or shutdown cleanly.