### PR TITLE
Initial offset spec

### DIFF
--- a/proto/proximo.proto
+++ b/proto/proximo.proto
@@ -9,7 +9,8 @@ message Message {
 
 // Consumer types
 service MessageSource {
-	rpc Consume(stream ConsumerRequest) returns (stream Message) {}
+  rpc Consume(stream ConsumerRequest) returns (stream Message) {
+  }
 }
 
 message ConsumerRequest {
@@ -30,7 +31,8 @@ message Confirmation {
 
 // Producer types
 service MessageSink {
-	rpc Publish(stream PublisherRequest) returns (stream Confirmation) {}
+  rpc Publish(stream PublisherRequest) returns (stream Confirmation) {
+  }
 }
 
 message PublisherRequest {

--- a/proto/proximo.proto
+++ b/proto/proximo.proto
@@ -23,6 +23,13 @@ message ConsumerRequest {
 message StartConsumeRequest {
   string topic = 1;
   string consumer = 2;
+  Offset initial_offset = 3;
+}
+
+enum Offset {
+  OFFSET_DEFAULT = 0;
+  OFFSET_NEWEST = 1;
+  OFFSET_OLDEST = 2;
 }
 
 message Confirmation {


### PR DESCRIPTION
This adds support for a consumer specifying initial offsets when connecting to a proximo server, but this does not yet implement anything.