### PR TITLE
Introduce config structs

### DIFF
--- a/proximo-server/server_test.go
+++ b/proximo-server/server_test.go
@@ -87,11 +87,11 @@ type mockProduceHandler struct {
 	releaseOne chan struct{}
 }
 
-func (mh *mockProduceHandler) HandleConsume(ctx context.Context, consumer, topic string, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
+func (mh *mockProduceHandler) HandleConsume(ctx context.Context, conf consumerConfig, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
 	panic("this mock does not handle consume")
 }
 
-func (mh *mockProduceHandler) HandleProduce(ctx context.Context, topic string, forClient chan<- *Confirmation, messages <-chan *Message) error {
+func (mh *mockProduceHandler) HandleProduce(ctx context.Context, conf producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error {
 
 	go mh.loop(forClient, messages)
 


### PR DESCRIPTION
This introduces a config struct for the configuration of both consumer
and producer backends.  This adds nothing new to the struct, it merely
moves existing config options onto it, so that future changes that add
config options, code churn is minimised.