### PR TITLE
Connect to NATS streaming in constructor function

### DIFF
--- a/proximo-server/main.go
+++ b/proximo-server/main.go
@@ -100,10 +100,11 @@ func main() {
 			}
 			var opts []grpc.ServerOption
 			grpcServer := grpc.NewServer(opts...)
-			kh := &natsStreamingHandler{
-				url:       *url,
-				clusterID: *cid,
+			kh, err := newNatsStreamingHandler(*url, *cid)
+			if err != nil {
+				log.Fatalf("failed to connect to nats streaming: %v", err)
 			}
+			defer kh.Close()
 			log.Printf("Using NATS streaming server at %s with cluster id %s\n", *url, *cid)
 			registerGRPCServers(grpcServer, &server{kh}, *endpoints)
 			log.Fatal(grpcServer.Serve(lis))


### PR DESCRIPTION
Instead of connecting "on demand" in the publish and consume functions,
we connect earlier and use the connection when publishing and consuming.

This paves the way for adding status check like functionality more
easily that can also re-use the connection.