### PR TITLE
Wrapper backends

### DIFF
--- a/pkg/backend/callback.go
+++ b/pkg/backend/callback.go
@@ -1,0 +1,119 @@
+package backend
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/uw-labs/proximo/pkg/proto"
+)
+
+type CallbackHandler struct {
+	Delegate Handler
+
+	BeforeConsume    func(msg *proto.Message)
+	BeforeProduce    func(msg *proto.Message)
+	BeforeConsumeAck func(ack *proto.Confirmation)
+	BeforeProduceAck func(ack *proto.Confirmation)
+
+	OnConsumeError func(err error)
+	OnProduceError func(err error)
+}
+
+func (h *CallbackHandler) HandleConsume(ctx context.Context, conf ConsumerConfig, forClient chan<- *proto.Message, confirmRequest <-chan *proto.Confirmation) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	delegateForClient, delegateConfirmRequest := forClient, confirmRequest
+
+	if h.BeforeConsume != nil {
+		fromDelegate := make(chan *proto.Message)
+		delegateForClient = fromDelegate
+
+		eg.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case msg := <-fromDelegate:
+					h.BeforeConsume(msg)
+					forClient <- msg
+				}
+			}
+		})
+	}
+
+	if h.BeforeConsumeAck != nil {
+		toDelegate := make(chan *proto.Confirmation)
+		delegateConfirmRequest = toDelegate
+
+		eg.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case ack := <-confirmRequest:
+					h.BeforeConsumeAck(ack)
+					toDelegate <- ack
+				}
+			}
+		})
+	}
+
+	eg.Go(func() error {
+		return h.Delegate.HandleConsume(ctx, conf, delegateForClient, delegateConfirmRequest)
+	})
+
+	err := eg.Wait()
+	if err != nil && h.OnConsumeError != nil {
+		h.OnConsumeError(err)
+	}
+	return err
+}
+
+func (h *CallbackHandler) HandleProduce(ctx context.Context, conf ProducerConfig, forClient chan<- *proto.Confirmation, messages <-chan *proto.Message) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	delegateForClient, delegateMessages := forClient, messages
+
+	if h.BeforeProduce != nil {
+		toDelegate := make(chan *proto.Message)
+		delegateMessages = toDelegate
+
+		eg.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case msg := <-messages:
+					h.BeforeProduce(msg)
+					toDelegate <- msg
+				}
+			}
+		})
+	}
+
+	if h.BeforeProduceAck != nil {
+		fromDelegate := make(chan *proto.Confirmation)
+		delegateForClient = fromDelegate
+
+		eg.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case ack := <-fromDelegate:
+					h.BeforeProduceAck(ack)
+					forClient <- ack
+				}
+			}
+		})
+	}
+
+	eg.Go(func() error {
+		return h.Delegate.HandleProduce(ctx, conf, delegateForClient, delegateMessages)
+	})
+
+	err := eg.Wait()
+	if err != nil && h.OnProduceError != nil {
+		h.OnProduceError(err)
+	}
+	return err
+}

--- a/pkg/backend/filter.go
+++ b/pkg/backend/filter.go
@@ -1,0 +1,48 @@
+package backend
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/uw-labs/proximo/pkg/proto"
+)
+
+type filterHandler struct {
+	delegate      Handler
+	consumeTopics map[string]bool
+	produceTopics map[string]bool
+}
+
+// NewFilterHandler returns a handler that only allows access to topics specified in the provided maps
+func NewFilterHandler(consumeTopics map[string]bool, produceTopics map[string]bool, delegate Handler) (Handler, error) {
+	if delegate == nil {
+		return nil, ErrNoDelegate
+	}
+
+	return &filterHandler{
+		delegate:      delegate,
+		consumeTopics: consumeTopics,
+	}, nil
+}
+
+func (h *filterHandler) HandleConsume(ctx context.Context, conf ConsumerConfig, forClient chan<- *proto.Message, confirmRequest <-chan *proto.Confirmation) error {
+	if h.consumeTopics != nil {
+		if allowed := h.consumeTopics[conf.Topic]; !allowed {
+			return status.Errorf(codes.PermissionDenied, "not allowed to consume from topic with name `%s`", conf.Topic)
+		}
+	}
+
+	return h.delegate.HandleConsume(ctx, conf, forClient, confirmRequest)
+}
+
+func (h *filterHandler) HandleProduce(ctx context.Context, conf ProducerConfig, forClient chan<- *proto.Confirmation, messages <-chan *proto.Message) error {
+	if h.produceTopics != nil {
+		if allowed := h.produceTopics[conf.Topic]; !allowed {
+			return status.Errorf(codes.PermissionDenied, "not allowed to produce to topic with name `%s`", conf.Topic)
+		}
+	}
+
+	return h.delegate.HandleProduce(ctx, conf, forClient, messages)
+}

--- a/pkg/backend/mapping.go
+++ b/pkg/backend/mapping.go
@@ -1,0 +1,41 @@
+package backend
+
+import (
+	"context"
+	"errors"
+
+	"github.com/uw-labs/proximo/pkg/proto"
+)
+
+var ErrNoDelegate = errors.New("no delegate specified")
+
+type mappingHandler struct {
+	delegate Handler
+	topicMap map[string]string
+}
+
+// NewMappingHandler returns a handler than maps topics according to the provided map
+func NewMappingHandler(topicMap map[string]string, delegate Handler) (Handler, error) {
+	if delegate == nil {
+		return nil, ErrNoDelegate
+	}
+
+	return &mappingHandler{
+		delegate: delegate,
+		topicMap: topicMap,
+	}, nil
+}
+
+func (h *mappingHandler) HandleConsume(ctx context.Context, conf ConsumerConfig, forClient chan<- *proto.Message, confirmRequest <-chan *proto.Confirmation) error {
+	if topic, ok := h.topicMap[conf.Topic]; ok {
+		conf.Topic = topic
+	}
+	return h.delegate.HandleConsume(ctx, conf, forClient, confirmRequest)
+}
+
+func (h *mappingHandler) HandleProduce(ctx context.Context, conf ProducerConfig, forClient chan<- *proto.Confirmation, messages <-chan *proto.Message) error {
+	if topic, ok := h.topicMap[conf.Topic]; ok {
+		conf.Topic = topic
+	}
+	return h.delegate.HandleProduce(ctx, conf, forClient, messages)
+}


### PR DESCRIPTION
Examples of wrapper backends. The callback handler can be easily used to add metrics to the server. We don't necessarily need to merge this PR, it's mainly meant as collection of examples to show advantages of having the server as a library.