### PR TITLE
Split the handler interface 

### DIFF
--- a/proximo-server/amqp.go
+++ b/proximo-server/amqp.go
@@ -98,7 +98,3 @@ func (h *amqpHandler) HandleConsume(ctx context.Context, conf consumerConfig, fo
 		}
 	}
 }
-
-func (h *amqpHandler) HandleProduce(ctx context.Context, conf producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error {
-	panic("not implemented")
-}

--- a/proximo-server/kafka.go
+++ b/proximo-server/kafka.go
@@ -13,12 +13,12 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-type kafkaHandler struct {
+type kafkaConsumeHandler struct {
 	brokers []string
 	version *sarama.KafkaVersion
 }
 
-func (h *kafkaHandler) HandleConsume(ctx context.Context, conf consumerConfig, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
+func (h *kafkaConsumeHandler) HandleConsume(ctx context.Context, conf consumerConfig, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
 	toConfirmIds := make(chan string)
 
 	errors := make(chan error)
@@ -73,7 +73,7 @@ func (h *kafkaHandler) HandleConsume(ctx context.Context, conf consumerConfig, f
 	}
 }
 
-func (h *kafkaHandler) consume(ctx context.Context, c *cluster.Consumer, forClient chan<- *Message, toConfirmID chan string, topic, consumer string) error {
+func (h *kafkaConsumeHandler) consume(ctx context.Context, c *cluster.Consumer, forClient chan<- *Message, toConfirmID chan string, topic, consumer string) error {
 
 	grpclog.Println("started consume loop")
 	defer grpclog.Println("exited consume loop")
@@ -107,7 +107,7 @@ func (h *kafkaHandler) consume(ctx context.Context, c *cluster.Consumer, forClie
 	}
 }
 
-func (h *kafkaHandler) confirm(ctx context.Context, c *cluster.Consumer, id string, topic string) error {
+func (h *kafkaConsumeHandler) confirm(ctx context.Context, c *cluster.Consumer, id string, topic string) error {
 	spl := strings.Split(id, "-")
 	o, err := strconv.ParseInt(spl[0], 10, 64)
 	if err != nil {
@@ -121,7 +121,12 @@ func (h *kafkaHandler) confirm(ctx context.Context, c *cluster.Consumer, id stri
 	return nil
 }
 
-func (h *kafkaHandler) HandleProduce(ctx context.Context, cfg producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error {
+type kafkaProduceHandler struct {
+	brokers []string
+	version *sarama.KafkaVersion
+}
+
+func (h *kafkaProduceHandler) HandleProduce(ctx context.Context, cfg producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error {
 	conf := sarama.NewConfig()
 	conf.Producer.Return.Successes = true
 	conf.Producer.RequiredAcks = sarama.WaitForAll

--- a/proximo-server/nats-streaming.go
+++ b/proximo-server/nats-streaming.go
@@ -14,26 +14,26 @@ import (
 	"github.com/nats-io/go-nats-streaming/pb"
 )
 
-type natsStreamingHandler struct {
+type natsStreamingConsumeHandler struct {
 	clusterID   string
 	maxInflight int
 	nc          *nats.Conn
 }
 
-func newNatsStreamingHandler(url, clusterID string, maxInflight int) (*natsStreamingHandler, error) {
+func newNatsStreamingConsumeHandler(url, clusterID string, maxInflight int) (*natsStreamingConsumeHandler, error) {
 	nc, err := nats.Connect(url, nats.Name("proximo-nats-streaming-"+generateID()))
 	if err != nil {
 		return nil, err
 	}
-	return &natsStreamingHandler{nc: nc, clusterID: clusterID, maxInflight: maxInflight}, nil
+	return &natsStreamingConsumeHandler{nc: nc, clusterID: clusterID, maxInflight: maxInflight}, nil
 }
 
-func (h *natsStreamingHandler) Close() error {
+func (h *natsStreamingConsumeHandler) Close() error {
 	h.nc.Close()
 	return nil
 }
 
-func (h *natsStreamingHandler) HandleConsume(ctx context.Context, conf consumerConfig, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
+func (h *natsStreamingConsumeHandler) HandleConsume(ctx context.Context, conf consumerConfig, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
 
 	conn, err := stan.Connect(h.clusterID, conf.consumer+generateID(), stan.NatsConn(h.nc))
 	if err != nil {
@@ -121,7 +121,26 @@ func (h *natsStreamingHandler) HandleConsume(ctx context.Context, conf consumerC
 
 }
 
-func (h *natsStreamingHandler) HandleProduce(ctx context.Context, conf producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error {
+type natsStreamingProduceHandler struct {
+	clusterID   string
+	maxInflight int
+	nc          *nats.Conn
+}
+
+func newNatsStreamingProduceHandler(url, clusterID string, maxInflight int) (*natsStreamingProduceHandler, error) {
+	nc, err := nats.Connect(url, nats.Name("proximo-nats-streaming-"+generateID()))
+	if err != nil {
+		return nil, err
+	}
+	return &natsStreamingProduceHandler{nc: nc, clusterID: clusterID, maxInflight: maxInflight}, nil
+}
+
+func (h *natsStreamingProduceHandler) Close() error {
+	h.nc.Close()
+	return nil
+}
+
+func (h *natsStreamingProduceHandler) HandleProduce(ctx context.Context, conf producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error {
 
 	conn, err := stan.Connect(h.clusterID, generateID(), stan.NatsConn(h.nc))
 	if err != nil {

--- a/proximo-server/server.go
+++ b/proximo-server/server.go
@@ -23,16 +23,19 @@ type producerConfig struct {
 	topic string
 }
 
-type handler interface {
+type consumeHandler interface {
 	HandleConsume(ctx context.Context, conf consumerConfig, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error
+}
+
+type produceHandler interface {
 	HandleProduce(ctx context.Context, conf producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error
 }
 
-type server struct {
-	handler handler
+type consumeServer struct {
+	handler consumeHandler
 }
 
-func (s *server) Consume(stream MessageSource_ConsumeServer) error {
+func (s *consumeServer) Consume(stream MessageSource_ConsumeServer) error {
 
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
@@ -135,11 +138,15 @@ type messageSink_PublishServer interface {
 	Context() context.Context
 }
 
-func (s *server) Publish(stream MessageSink_PublishServer) error {
+type produceServer struct {
+	handler produceHandler
+}
+
+func (s *produceServer) Publish(stream MessageSink_PublishServer) error {
 	return s.publish(stream)
 }
 
-func (s *server) publish(stream messageSink_PublishServer) error {
+func (s *produceServer) publish(stream messageSink_PublishServer) error {
 
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()

--- a/proximo-server/server_test.go
+++ b/proximo-server/server_test.go
@@ -13,7 +13,7 @@ import (
 func TestProduceCloseWithAckPending(t *testing.T) {
 	handler := newMockProduceHandler()
 
-	svr := &server{handler}
+	svr := &produceServer{handler}
 
 	tscs := newTestMessageSourceProduceServer()
 
@@ -85,10 +85,6 @@ func newMockProduceHandler() *mockProduceHandler {
 type mockProduceHandler struct {
 	// write to this chan to release a confirmation for a message that's been sent.
 	releaseOne chan struct{}
-}
-
-func (mh *mockProduceHandler) HandleConsume(ctx context.Context, conf consumerConfig, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
-	panic("this mock does not handle consume")
 }
 
 func (mh *mockProduceHandler) HandleProduce(ctx context.Context, conf producerConfig, forClient chan<- *Confirmation, messages <-chan *Message) error {


### PR DESCRIPTION
Split the handler interface  and its implementations as well as server to two to make it easier to migrate to substrate backend.