### PR TITLE
Move logic from Consume and Publish functions to separate methods.

### DIFF
--- a/proximo-server/server_source.go
+++ b/proximo-server/server_source.go
@@ -43,61 +43,11 @@ func (s *consumeServer) Consume(stream proto.MessageSource_ConsumeServer) error 
 	startRequest := make(chan *proto.StartConsumeRequest)
 
 	g.Go(func() error {
-		started := false
-		for {
-			msg, err := stream.Recv()
-			if err != nil {
-				if err == io.EOF {
-					return nil
-				}
-				if strings.HasSuffix(err.Error(), "context canceled") {
-					return nil
-				}
-				return err
-			}
-			switch {
-			case msg.GetStartRequest() != nil:
-				if started {
-					return errStartedTwice
-				}
-				started = true
-				select {
-				case startRequest <- msg.GetStartRequest():
-				case <-ctx.Done():
-					return nil
-				}
-			case msg.GetConfirmation() != nil:
-				if !started {
-					return errInvalidConfirm
-				}
-				select {
-				case confirmRequest <- msg.GetConfirmation():
-				case <-ctx.Done():
-					return nil
-				}
-			default:
-				return errInvalidRequest
-			}
-		}
+		return s.receiveConfirmations(ctx, stream, startRequest, confirmRequest)
 	})
-
 	g.Go(func() error {
-		for {
-			select {
-			case m := <-forClient:
-				err := stream.Send(m)
-				if err != nil {
-					if strings.HasSuffix(err.Error(), "context canceled") {
-						return nil
-					}
-					return err
-				}
-			case <-ctx.Done():
-				return nil
-			}
-		}
+		return s.sendMessages(ctx, stream, forClient)
 	})
-
 	g.Go(func() error {
 		var conf consumerConfig
 		select {
@@ -120,4 +70,72 @@ func (s *consumeServer) Consume(stream proto.MessageSource_ConsumeServer) error 
 		return status.Error(codes.Canceled, err.Error())
 	}
 	return sCtx.Err()
+}
+
+// receiveSourceStream is a subset of proto.MessageSource_ConsumeServer that only exposes the receive method
+type receiveSourceStream interface {
+	Recv() (*proto.ConsumerRequest, error)
+}
+
+// receiveConfirmations receives confirmations from the client
+func (s *consumeServer) receiveConfirmations(ctx context.Context, stream receiveSourceStream, startRequest chan<- *proto.StartConsumeRequest, confirmRequest chan<- *proto.Confirmation) error {
+	started := false
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			if strings.HasSuffix(err.Error(), "context canceled") {
+				return nil
+			}
+			return err
+		}
+		switch {
+		case msg.GetStartRequest() != nil:
+			if started {
+				return errStartedTwice
+			}
+			started = true
+			select {
+			case startRequest <- msg.GetStartRequest():
+			case <-ctx.Done():
+				return nil
+			}
+		case msg.GetConfirmation() != nil:
+			if !started {
+				return errInvalidConfirm
+			}
+			select {
+			case confirmRequest <- msg.GetConfirmation():
+			case <-ctx.Done():
+				return nil
+			}
+		default:
+			return errInvalidRequest
+		}
+	}
+}
+
+// sendSourceStream is a subset of proto.MessageSource_ConsumeServer that only exposes the send method
+type sendSourceStream interface {
+	Send(*proto.Message) error
+}
+
+// sendMessages sends messages to the client
+func (s *consumeServer) sendMessages(ctx context.Context, stream sendSourceStream, forClient <-chan *proto.Message) error {
+	for {
+		select {
+		case m := <-forClient:
+			err := stream.Send(m)
+			if err != nil {
+				if strings.HasSuffix(err.Error(), "context canceled") {
+					return nil
+				}
+				return err
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
 }

--- a/proximoc-go/proximo.go
+++ b/proximoc-go/proximo.go
@@ -2,44 +2,65 @@ package proximoc
 
 import "github.com/uw-labs/proximo/proto"
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type Offset = proto.Offset
 
 const (
+	// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 	Offset_OFFSET_DEFAULT = proto.Offset_OFFSET_DEFAULT
-	Offset_OFFSET_NEWEST  = proto.Offset_OFFSET_NEWEST
-	Offset_OFFSET_OLDEST  = proto.Offset_OFFSET_OLDEST
+	// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
+	Offset_OFFSET_NEWEST = proto.Offset_OFFSET_NEWEST
+	// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
+	Offset_OFFSET_OLDEST = proto.Offset_OFFSET_OLDEST
 )
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type Message = proto.Message
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type ConsumerRequest = proto.ConsumerRequest
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type StartConsumeRequest = proto.StartConsumeRequest
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type Confirmation = proto.Confirmation
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type PublisherRequest = proto.PublisherRequest
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type StartPublishRequest = proto.StartPublishRequest
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type MessageSourceClient = proto.MessageSourceClient
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 var NewMessageSourceClient = proto.NewMessageSourceClient
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type MessageSource_ConsumeClient = proto.MessageSource_ConsumeClient
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type MessageSourceServer = proto.MessageSourceServer
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 var RegisterMessageSourceServer = proto.RegisterMessageSourceServer
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type MessageSource_ConsumeServer = proto.MessageSource_ConsumeServer
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type MessageSinkClient = proto.MessageSinkClient
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 var NewMessageSinkClient = proto.NewMessageSinkClient
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type MessageSink_PublishClient = proto.MessageSink_PublishClient
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 type MessageSinkServer = proto.MessageSinkServer
 
+// Deprecated: Use https://github.com/uw-labs/proximo/proto instead
 var RegisterMessageSinkServer = proto.RegisterMessageSinkServer


### PR DESCRIPTION
I've moved logic from inline functions to separate methods on the servers, no other changes were made in this branch. This limits the access to the methods of the stream object and channels to the minimum required. It should also simplify migration to substrate backend going forward and is cleaner in my opinion.

I've based this on the branch that fixes CI, to avoid having failing build.