### PR TITLE
Return unavailable error to clients instead of nil to signal that a backend connection was closed

### DIFF
--- a/server_sink.go
+++ b/server_sink.go
@@ -5,9 +5,6 @@ import (
 	"io"
 	"strings"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/pkg/errors"
 	"github.com/uw-labs/proximo/proto"
 	"github.com/uw-labs/substrate"
@@ -53,11 +50,7 @@ func (s *SinkServer) Publish(stream proto.MessageSink_PublishServer) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
-
-	if err := sCtx.Err(); err == context.Canceled {
-		return status.Error(codes.Canceled, err.Error())
-	}
-	return sCtx.Err()
+	return errConnectionClosed
 }
 
 // receiveSinkStream is a subset of proto.MessageSink_PublishServer that only exposes the receive method

--- a/server_source.go
+++ b/server_source.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
-	errStartedTwice   = status.Error(codes.InvalidArgument, "consumption already started")
-	errInvalidConfirm = status.Error(codes.InvalidArgument, "invalid confirmation")
-	errNotConnected   = status.Error(codes.InvalidArgument, "not connected to a topic")
-	errInvalidRequest = status.Error(codes.InvalidArgument, "invalid consumer request - this is possibly a bug in your client library")
+	errStartedTwice     = status.Error(codes.InvalidArgument, "consumption already started")
+	errInvalidConfirm   = status.Error(codes.InvalidArgument, "invalid confirmation")
+	errNotConnected     = status.Error(codes.InvalidArgument, "not connected to a topic")
+	errInvalidRequest   = status.Error(codes.InvalidArgument, "invalid consumer request - this is possibly a bug in your client library")
+	errConnectionClosed = status.Error(codes.Unavailable, "backend connection was closed")
 )
 
 type SourceServer struct {
@@ -66,11 +67,7 @@ func (s *SourceServer) Consume(stream proto.MessageSource_ConsumeServer) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
-
-	if err := sCtx.Err(); err == context.Canceled {
-		return status.Error(codes.Canceled, err.Error())
-	}
-	return sCtx.Err()
+	return errConnectionClosed
 }
 
 // receiveSourceStream is a subset of proto.MessageSource_ConsumeServer that only exposes the receive method

--- a/server_test.go
+++ b/server_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -133,7 +135,7 @@ func TestConsumeServer_Consume(t *testing.T) {
 		consumed = append(consumed, msg)
 		return nil
 	})
-	assert.NoError(err)
+	assert.Equal(status.Code(err), codes.Unavailable)
 	assert.Equal(len(expected), len(consumed))
 
 	for i, msg := range expected {


### PR DESCRIPTION
A backend connection should be open non stop, so when it's closed we should present this to client as an error.