### PR TITLE
Bump substrate and expose consumer session timeout.

### DIFF
--- a/backend/kafka/kafka.go
+++ b/backend/kafka/kafka.go
@@ -14,6 +14,7 @@ type AsyncSourceFactory struct {
 	Version                  string
 	OffsetsRetention         time.Duration
 	MetadataRefreshFrequency time.Duration
+	SessionTimeout           time.Duration
 }
 
 func (f AsyncSourceFactory) NewAsyncSource(ctx context.Context, req *proto.StartConsumeRequest) (substrate.AsyncMessageSource, error) {
@@ -32,6 +33,7 @@ func (f AsyncSourceFactory) NewAsyncSource(ctx context.Context, req *proto.Start
 		Version:                  f.Version,
 		OffsetsRetention:         f.OffsetsRetention,
 		MetadataRefreshFrequency: f.MetadataRefreshFrequency,
+		SessionTimeout:           f.SessionTimeout,
 	})
 }
 

--- a/cmd/proximo-server/main.go
+++ b/cmd/proximo-server/main.go
@@ -67,14 +67,20 @@ func main() {
 			Desc:   "Kafka Version e.g. 1.1.1, 0.10.2.0",
 			EnvVar: "PROXIMO_KAFKA_VERSION",
 		})
+		kafkaConsumerSessionTimeout := cmd.Int(cli.IntOpt{
+			Name:   "consumer-session-timeout",
+			Desc:   "Duration in seconds after which consumer session should timeout.",
+			EnvVar: "PROXIMO_KAFKA_CONSUMER_SESSION_TIMEOUT",
+		})
 
 		cmd.Action = func() {
 			brokers := strings.Split(*brokerString, ",")
 
 			if enabled[consumeEndpoint] {
 				sourceFactory = &kafka.AsyncSourceFactory{
-					Brokers: brokers,
-					Version: *kafkaVersion,
+					Brokers:        brokers,
+					Version:        *kafkaVersion,
+					SessionTimeout: time.Duration(*kafkaConsumerSessionTimeout) * time.Second,
 				}
 			}
 			if enabled[publishEndpoint] {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.22.2
-	github.com/uw-labs/substrate v0.0.0-20200228142927-9d6c72285990
+	github.com/uw-labs/substrate v0.0.0-20200325102738-bcdc00ce7555
 	github.com/uw-labs/sync v0.0.0-20190307114256-1bb306bf6e71
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	google.golang.org/grpc v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/uw-labs/freezer v0.0.0-20200217144949-6d67e7edcab8/go.mod h1:fVLLU+8t
 github.com/uw-labs/proximo v0.0.0-20190913093050-8229af78f5dd/go.mod h1:qvhJ61jBx9RI4vrThNU4jroHCMpbU850pzmm+1b4fYk=
 github.com/uw-labs/straw v0.0.0-20200213162553-01e9a0f94f69/go.mod h1:V/HU8rEA5SCAbjS32ztEM2s6yt9PxqTRH9BLlmGRnAE=
 github.com/uw-labs/substrate v0.0.0-20190606111548-e9b3a4b7c12c/go.mod h1:dyyAUJcMCwdJ5EaYf8bh2rCNvSH9wwQEIpfZwt+bOn8=
-github.com/uw-labs/substrate v0.0.0-20200228142927-9d6c72285990 h1:DYDZTF4pZ9dtZnd/iurpE0m5k3WbvbiizudoPykdwGQ=
-github.com/uw-labs/substrate v0.0.0-20200228142927-9d6c72285990/go.mod h1:2hnvoJuiq8PLbhEgsgZJQfNgGjwjwDp9zpu8xz7UE2k=
+github.com/uw-labs/substrate v0.0.0-20200325102738-bcdc00ce7555 h1:+j282/vIbSTvYUtpvcDyn2CogMMjVOh5R6Uobh2ZkI0=
+github.com/uw-labs/substrate v0.0.0-20200325102738-bcdc00ce7555/go.mod h1:2hnvoJuiq8PLbhEgsgZJQfNgGjwjwDp9zpu8xz7UE2k=
 github.com/uw-labs/sync v0.0.0-20190307114256-1bb306bf6e71 h1:1fL6kfRp9ebXBzK3powp5uKM3dCtK62RCiadQDqcR1Q=
 github.com/uw-labs/sync v0.0.0-20190307114256-1bb306bf6e71/go.mod h1:zTU/pesbF9d3ZN7+XwKhdE50y0SCCblmzwukXRnZkXs=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=


### PR DESCRIPTION
This makes kafka consumer session timeout configurable,
so that users can adjust it to their broker configuration.