### PR TITLE
PLA2-120: revert backend connection close commit

### DIFF
--- a/server_sink.go
+++ b/server_sink.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"strings"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/pkg/errors"
 	"github.com/uw-labs/proximo/proto"
 	"github.com/uw-labs/substrate"
@@ -50,7 +53,11 @@ func (s *SinkServer) Publish(stream proto.MessageSink_PublishServer) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	return errConnectionClosed
+
+	if err := sCtx.Err(); err == context.Canceled {
+		return status.Error(codes.Canceled, err.Error())
+	}
+	return sCtx.Err()
 }
 
 // receiveSinkStream is a subset of proto.MessageSink_PublishServer that only exposes the receive method

--- a/server_source.go
+++ b/server_source.go
@@ -15,11 +15,10 @@ import (
 )
 
 var (
-	errStartedTwice     = status.Error(codes.InvalidArgument, "consumption already started")
-	errInvalidConfirm   = status.Error(codes.InvalidArgument, "invalid confirmation")
-	errNotConnected     = status.Error(codes.InvalidArgument, "not connected to a topic")
-	errInvalidRequest   = status.Error(codes.InvalidArgument, "invalid consumer request - this is possibly a bug in your client library")
-	errConnectionClosed = status.Error(codes.Unavailable, "backend connection was closed")
+	errStartedTwice   = status.Error(codes.InvalidArgument, "consumption already started")
+	errInvalidConfirm = status.Error(codes.InvalidArgument, "invalid confirmation")
+	errNotConnected   = status.Error(codes.InvalidArgument, "not connected to a topic")
+	errInvalidRequest = status.Error(codes.InvalidArgument, "invalid consumer request - this is possibly a bug in your client library")
 )
 
 type SourceServer struct {
@@ -68,7 +67,11 @@ func (s *SourceServer) Consume(stream proto.MessageSource_ConsumeServer) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	return errConnectionClosed
+
+	if err := sCtx.Err(); err == context.Canceled {
+		return status.Error(codes.Canceled, err.Error())
+	}
+	return sCtx.Err()
 }
 
 // receiveSourceStream is a subset of proto.MessageSource_ConsumeServer that only exposes the receive method

--- a/server_source.go
+++ b/server_source.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"errors"
 	"github.com/uw-labs/proximo/internal/id"
 	"github.com/uw-labs/proximo/proto"
 	"github.com/uw-labs/substrate"
@@ -68,7 +69,7 @@ func (s *SourceServer) Consume(stream proto.MessageSource_ConsumeServer) error {
 		return err
 	}
 
-	if err := sCtx.Err(); err == context.Canceled {
+	if err := sCtx.Err(); errors.Is(err, context.Canceled) {
 		return status.Error(codes.Canceled, err.Error())
 	}
 	return sCtx.Err()

--- a/server_test.go
+++ b/server_test.go
@@ -10,10 +10,8 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
-	"google.golang.org/grpc/status"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -136,7 +134,7 @@ func TestConsumeServer_Consume(t *testing.T) {
 		consumed = append(consumed, msg)
 		return nil
 	})
-	assert.Equal(status.Code(err), codes.Unavailable)
+	assert.NoError(err)
 	assert.Equal(len(expected), len(consumed))
 
 	for i, msg := range expected {


### PR DESCRIPTION
- **Revert "Return unavailable error to clients instead of nil to signal that a backend connection was closed."**

This was misleading the clients to think that there was an error while the consumtion & producing was terminated cleanly.
