### PR TITLE
DENA-938: Added more information when permission is denied

### DIFF
--- a/backend/acl/config_test.go
+++ b/backend/acl/config_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -85,7 +87,14 @@ clients:
 	ctx := createCtx("dog-consumer", "123")
 	_, err = c.GetClientScope(ctx)
 
-	assert.Equal(err, ErrUnauthorized)
+	assertPermissionDenied(t, err, "passwords do not match")
+}
+
+func assertPermissionDenied(t *testing.T, err error, expString string) {
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.PermissionDenied, s.Code())
+	require.ErrorContains(t, err, expString)
 }
 
 func Test_ClientWithNoAuthHasDefaultAccess(t *testing.T) {

--- a/backend/acl/sink.go
+++ b/backend/acl/sink.go
@@ -6,6 +6,8 @@ import (
 	"github.com/uw-labs/proximo"
 	"github.com/uw-labs/proximo/proto"
 	"github.com/uw-labs/substrate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type AsyncSinkFactory struct {
@@ -20,7 +22,7 @@ func (s AsyncSinkFactory) NewAsyncSink(ctx context.Context, req *proto.StartPubl
 	}
 
 	if !containsRegex(scope.Publish, req.Topic) {
-		return nil, ErrUnauthorized
+		return nil, status.Errorf(codes.PermissionDenied, "no publish permissions for topic %v", req.Topic)
 	}
 
 	return s.Next.NewAsyncSink(ctx, req)

--- a/backend/acl/sink_test.go
+++ b/backend/acl/sink_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func Test_FactoryConsumeOnlyClientCannotPublish(t *testing.T) {
-	assert := require.New(t)
 
 	c, err := ConfigFromString(fmt.Sprintf(`
 default:
@@ -37,7 +36,7 @@ clients:
 		Topic: "dogs",
 	})
 
-	assert.Equal(err, ErrUnauthorized)
+	assertPermissionDenied(t, err, "no publish permissions for topic dogs")
 }
 
 func Test_FactoryPublishOnlyClientCanPublish(t *testing.T) {

--- a/backend/acl/source.go
+++ b/backend/acl/source.go
@@ -6,6 +6,8 @@ import (
 	"github.com/uw-labs/proximo"
 	"github.com/uw-labs/proximo/proto"
 	"github.com/uw-labs/substrate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type AsyncSourceFactory struct {
@@ -20,7 +22,7 @@ func (s AsyncSourceFactory) NewAsyncSource(ctx context.Context, req *proto.Start
 	}
 
 	if !containsRegex(scope.Consume, req.Topic) {
-		return nil, ErrUnauthorized
+		return nil, status.Errorf(codes.PermissionDenied, "no consume permissions for topic %v", req.Topic)
 	}
 
 	return s.Next.NewAsyncSource(ctx, req)

--- a/backend/acl/source_test.go
+++ b/backend/acl/source_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func Test_FactoryPublishOnlyClientCannotConsume(t *testing.T) {
-	assert := require.New(t)
 
 	c, err := ConfigFromString(fmt.Sprintf(`
 default:
@@ -35,7 +34,7 @@ clients:
 		Topic: "dogs",
 	})
 
-	assert.Equal(err, ErrUnauthorized)
+	assertPermissionDenied(t, err, "no consume permissions for topic dogs")
 }
 
 func Test_FactoryConsumeOnlyClientCanConsume(t *testing.T) {


### PR DESCRIPTION
This is very useful when debugging integration issues.

Kept returning the grpc status Permission Denied, but added more details
This may bring some backwards compatibility issues, as we're removing an exported error