### PR TITLE
feat: Migrate from CircleCI to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install buf and protoc plugins
+        run: make install-tools
+
+      - name: Check proto files are up to date
+        run: make protos && git add --all && git diff --staged --exit-code
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race -cover ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Proximo [![CircleCI](https://circleci.com/gh/uw-labs/proximo.svg?style=svg)](https://circleci.com/gh/uw-labs/proximo)
+# Proximo [![CI](https://github.com/uw-labs/proximo/actions/workflows/ci.yml/badge.svg)](https://github.com/uw-labs/proximo/actions/workflows/ci.yml)
 Proximo is a proxy for multiple different publish-subscribe queuing systems.
 
 It is based on a GRPC interface definition, making it easy to create new client libraries.


### PR DESCRIPTION
Proposition to move to Github Actions to:
1. Streamline CI tools used in `uw-labs`
2. Fix CI - CircleCI does not seem to work (alternatively can fix it but with Github Actions it's two birds one stone :smile:  )


Planning to update buf next.