### PR TITLE
Fix ACL user-enumeration side-channel

### DIFF
--- a/backend/acl/config.go
+++ b/backend/acl/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -116,11 +117,13 @@ func (s *config) GetClientScope(ctx context.Context) (*Scope, error) {
 
 	hashPass, ok := s.auth[id]
 	if !ok {
-		return nil, status.Errorf(codes.PermissionDenied, "no password configured for id %v", id)
+		log.Printf("acl: no password configured for client %q", id)
+		return nil, status.Error(codes.PermissionDenied, "invalid credentials")
 	}
 
 	if err := bcrypt.CompareHashAndPassword(hashPass, []byte(secret)); err != nil {
-		return nil, status.Errorf(codes.PermissionDenied, "passwords do not match for id %v", id)
+		log.Printf("acl: wrong password for client %q", id)
+		return nil, status.Error(codes.PermissionDenied, "invalid credentials")
 	}
 
 	return s.scopes[id], nil

--- a/backend/acl/config_test.go
+++ b/backend/acl/config_test.go
@@ -87,7 +87,7 @@ clients:
 	ctx := createCtx("dog-consumer", "123")
 	_, err = c.GetClientScope(ctx)
 
-	assertPermissionDenied(t, err, "passwords do not match")
+	assertPermissionDenied(t, err, "invalid credentials")
 }
 
 func assertPermissionDenied(t *testing.T, err error, expString string) {


### PR DESCRIPTION
Unify error messages for missing client ID and wrong password so an attacker cannot distinguish valid client IDs from invalid ones.