### PR TITLE
Recover from panics in gRPC handlers

### DIFF
--- a/server_sink.go
+++ b/server_sink.go
@@ -17,7 +17,13 @@ type SinkServer struct {
 	SinkFactory AsyncSinkFactory
 }
 
-func (s *SinkServer) Publish(stream proto.MessageSink_PublishServer) error {
+func (s *SinkServer) Publish(stream proto.MessageSink_PublishServer) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = status.Errorf(codes.Internal, "panic: %v", r)
+		}
+	}()
+
 	sCtx := stream.Context()
 
 	g, ctx := gogroup.New(sCtx)
@@ -49,11 +55,12 @@ func (s *SinkServer) Publish(stream proto.MessageSink_PublishServer) error {
 		return sink.PublishMessages(ctx, acks, messages)
 	})
 
-	if err := g.Wait(); err != nil {
-		return err
+	if err = g.Wait(); err != nil {
+		return
 	}
 
-	return sCtx.Err()
+	err = sCtx.Err()
+	return
 }
 
 // receiveSinkStream is a subset of proto.MessageSink_PublishServer that only exposes the receive method

--- a/server_source.go
+++ b/server_source.go
@@ -25,7 +25,13 @@ type SourceServer struct {
 	SkipDiscard   bool
 }
 
-func (s *SourceServer) Consume(stream proto.MessageSource_ConsumeServer) error {
+func (s *SourceServer) Consume(stream proto.MessageSource_ConsumeServer) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = status.Errorf(codes.Internal, "panic: %v", r)
+		}
+	}()
+
 	sCtx := stream.Context()
 
 	g, ctx := gogroup.New(sCtx)
@@ -63,11 +69,12 @@ func (s *SourceServer) Consume(stream proto.MessageSource_ConsumeServer) error {
 		return source.ConsumeMessages(ctx, messages, acks)
 	})
 
-	if err := g.Wait(); err != nil {
-		return err
+	if err = g.Wait(); err != nil {
+		return
 	}
 
-	return sCtx.Err()
+	err = sCtx.Err()
+	return
 }
 
 // receiveSourceStream is a subset of proto.MessageSource_ConsumeServer that only exposes the receive method


### PR DESCRIPTION
Add defer recover() in SourceServer.Consume and SinkServer.Publish to catch panics from backend dependencies (e.g., sarama nil map when connecting to a non-existent Kafka topic) and convert them to gRPC Internal errors instead of crashing the server.

Fixes #88.